### PR TITLE
Contact Lists and Add Contacts

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,7 +1,66 @@
 class ContactsController < ApplicationController
   before_action :require_login
+  before_action :set_contact, only: [:edit_note, :update_note, :destroy]
 
   def index
+    @contacts = current_user.contact_users
+    @contact_map = current_user.contacts.each_with_object({}) { |contact, map| map[contact.contact_user_id] = contact }
+  end
 
+  def new
+    @users = User.available_for_contact(current_user)
+  end
+
+  def create
+    contact_user_id = params[:contact_user_id]
+    
+    if contact_user_id.blank?
+      redirect_to new_contact_path, alert: "Please select a contact"
+      return
+    end
+
+    contact_user = User.find_by(id: contact_user_id)
+    
+    if contact_user.nil?
+      redirect_to new_contact_path, alert: "User not found"
+      return
+    end
+
+    @contact = current_user.contacts.build(contact_user: contact_user)
+
+    if @contact.save
+      redirect_to contacts_path, notice: "Contact added successfully"
+    else
+      redirect_to new_contact_path, alert: "Failed to add contact: #{@contact.errors.full_messages.join(', ')}"
+    end
+  end
+
+  def edit_note
+    render :edit_note, layout: false
+  end
+
+  def update_note
+    if @contact.update(note: params[:contact][:note])
+      respond_to do |format|
+        format.js
+        format.html { redirect_to contacts_path, notice: "Note updated successfully" }
+      end
+    else
+      respond_to do |format|
+        format.js
+        format.html { render :edit_note, layout: false, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @contact.destroy
+    redirect_to contacts_path, notice: "Contact removed successfully"
+  end
+
+  private
+
+  def set_contact
+    @contact = current_user.contacts.find(params[:id])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  def calculate_age(date_of_birth)
+    return 0 unless date_of_birth
+
+    today = Date.today
+    age = today.year - date_of_birth.year
+    age -= 1 if today < date_of_birth.change(year: today.year)
+    age
+  end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,23 @@
+class Contact < ApplicationRecord
+  belongs_to :user
+  belongs_to :contact_user, class_name: 'User'
+
+  validates :user_id, :contact_user_id, presence: true
+  validates :contact_user_id, uniqueness: { scope: :user_id, message: "can only be added once per user" }
+  validate :cannot_add_self
+  validate :contact_user_exists
+
+  private
+
+  def cannot_add_self
+    if user_id == contact_user_id
+      errors.add(:contact_user_id, "cannot add yourself as a contact")
+    end
+  end
+
+  def contact_user_exists
+    unless User.exists?(contact_user_id)
+      errors.add(:contact_user_id, "must be a valid user")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,11 @@
 class User < ApplicationRecord
   has_secure_password
+  has_many :contacts, dependent: :destroy
+  has_many :contact_users, through: :contacts, source: :contact_user
 
   GENDERS = ["Male", "Female", "Non-binary", "Prefer not to say"].freeze
+
+  scope :available_for_contact, ->(user) { where.not(id: [user.id] + user.contact_users.pluck(:id)) }
 
   before_validation :downcase_email
 

--- a/app/views/contacts/edit_note.html.erb
+++ b/app/views/contacts/edit_note.html.erb
@@ -1,0 +1,38 @@
+<div id="note-modal-content" class="modal">
+  <h2>Edit Note for <%= @contact.contact_user.first_name %> <%= @contact.contact_user.last_name %></h2>
+
+  <%= form_with model: @contact, local: true, url: update_note_contact_path(@contact), method: :patch, remote: true do |f| %>
+    <% if @contact.errors.any? %>
+      <div id="error_explanation">
+        <h3><%= pluralize(@contact.errors.count, "error") %> prohibited this contact from being saved:</h3>
+        <ul>
+          <% @contact.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="field">
+      <%= f.label :note %>
+      <%= f.text_area :note, rows: 6, placeholder: "Add a note about this contact..." %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Update Note", class: "button" %>
+      <button type="button" class="button cancel-button" onclick="closeNoteModal()">Cancel</button>
+    </div>
+  <% end %>
+</div>
+
+<script>
+  function closeNoteModal() {
+    document.getElementById('note-modal').style.display = 'none';
+    document.getElementById('note-modal').innerHTML = '';
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('note-modal').style.display = 'block';
+  });
+</script>
+

--- a/app/views/contacts/edit_note.js.erb
+++ b/app/views/contacts/edit_note.js.erb
@@ -1,0 +1,7 @@
+document.getElementById('note-modal').innerHTML = '<%= escape_javascript(render(partial: "edit_note_form", locals: { contact: @contact })) %>';
+document.getElementById('note-modal').style.display = 'block';
+
+function closeNoteModal() {
+  document.getElementById('note-modal').style.display = 'none';
+  document.getElementById('note-modal').innerHTML = '';
+}

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -1,9 +1,68 @@
 <h1>Contacts</h1>
 
 <div class="contacts-toolbar">
-  <%= form_with url: contacts_path, method: :get, local: true do |f| %>
-    <%= f.text_field :q, placeholder: "Search Contacts", class: "contacts-search" %>
+  <%= form_with url: contacts_path, method: :get, local: true, id: "contacts-search-form" do |f| %>
+    <%= f.text_field :q, placeholder: "Search Contacts", class: "contacts-search", id: "contacts-search-input", value: params[:q] %>
   <% end %>
 
   <%= button_to "Add Contact", new_contact_path, class: "button add-contact", method: :get %>
 </div>
+
+<div id="note-modal" style="display: none;">
+  <!-- Modal will be populated by edit_note action -->
+</div>
+
+<% if @contacts.any? %>
+  <table class="contacts-table">
+    <thead>
+      <tr>
+        <th>First Name</th>
+        <th>Last Name</th>
+        <th>Occupation</th>
+        <th>Age</th>
+        <th>Hobbies</th>
+        <th>Likes</th>
+        <th>Dislikes</th>
+        <th>Note</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody id="contacts-list">
+      <% @contacts.each do |contact| %>
+        <% contact_info = @contact_map[contact.id] %>
+        <tr class="contact-row" data-contact-name="<%= (contact.first_name + ' ' + contact.last_name).downcase %>">
+          <td><%= contact.first_name %></td>
+          <td><%= contact.last_name %></td>
+          <td><%= contact.occupation %></td>
+          <td><%= calculate_age(contact.date_of_birth) %></td>
+          <td><%= contact.hobbies || "N/A" %></td>
+          <td><%= contact.likes || "N/A" %></td>
+          <td><%= contact.dislikes || "N/A" %></td>
+          <td><span id="note-<%= contact_info.id %>"><%= contact_info.note || "No note" %></span></td>
+          <td>
+            <%= link_to "Edit Note", edit_note_contact_path(contact_info), remote: true, class: "button edit-note" %>
+            <%= button_to "Delete", contact_path(contact_info), method: :delete, data: { confirm: "Are you sure?" }, class: "button delete-contact" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>No contacts yet. <%= link_to "Add one", new_contact_path %></p>
+<% end %>
+
+<script>
+  const searchInput = document.getElementById('contacts-search-input');
+  
+  if (searchInput) {
+    searchInput.addEventListener('keyup', function(e) {
+      const query = e.target.value.toLowerCase();
+      const rows = document.querySelectorAll('.contact-row');
+      
+      rows.forEach(row => {
+        const name = row.getAttribute('data-contact-name');
+        row.style.display = name.includes(query) ? '' : 'none';
+      });
+    });
+  }
+</script>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,0 +1,69 @@
+<h1>Add Contact</h1>
+
+<div class="add-contact-form">
+  <div class="search-section">
+    <h3>Search for a person to add as a contact</h3>
+    <%= form_with url: new_contact_path, method: :get, local: true, id: "users-search-form" do |search_f| %>
+      <%= search_f.text_field :q, placeholder: "Search by first or last name", class: "search-input", id: "users-search-input", value: params[:q] %>
+    <% end %>
+  </div>
+
+  <% if @users.any? %>
+    <div class="users-list">
+      <h3><%= params[:q].present? ? "Search Results:" : "All Available Users:" %></h3>
+      <table class="users-table">
+        <thead>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Email</th>
+            <th>Occupation</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody id="users-list">
+          <% @users.each do |user| %>
+            <tr class="user-row" data-user-name="<%= (user.first_name + ' ' + user.last_name).downcase %>">
+              <td><%= user.first_name %></td>
+              <td><%= user.last_name %></td>
+              <td><%= user.email %></td>
+              <td><%= user.occupation %></td>
+              <td>
+                <%= button_to "Add Contact", contacts_path, method: :post, params: { contact_user_id: user.id }, class: "button add-btn" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% elsif params[:q].present? %>
+    <p class="no-results-message">No users found matching "<%= params[:q] %>"</p>
+  <% end %>
+
+  <%= link_to "Back to Contacts", contacts_path, class: "button cancel-button" %>
+</div>
+
+<script>
+  const searchInput = document.getElementById('users-search-input');
+  const usersList = document.querySelector('.users-list');
+  const noResults = document.querySelector('.no-results-message');
+  
+  if (searchInput) {
+    searchInput.addEventListener('keyup', function(e) {
+      const query = e.target.value.toLowerCase();
+      const rows = document.querySelectorAll('.user-row');
+      let visibleCount = 0;
+      
+      rows.forEach(row => {
+        const name = row.getAttribute('data-user-name');
+        const isVisible = name.includes(query);
+        row.style.display = isVisible ? '' : 'none';
+        if (isVisible) visibleCount++;
+      });
+      
+      // Show/hide results message
+      if (usersList) usersList.style.display = visibleCount > 0 ? '' : 'none';
+      if (noResults) noResults.style.display = query && visibleCount === 0 ? '' : 'none';
+    });
+  }
+</script>

--- a/app/views/contacts/update_note.js.erb
+++ b/app/views/contacts/update_note.js.erb
@@ -1,0 +1,11 @@
+<% if @contact.save %>
+  // Update the note display in the table
+  document.getElementById('note-<%= @contact.id %>').textContent = '<%= @contact.note %>';
+  
+  // Close the modal
+  document.getElementById('note-modal').style.display = 'none';
+  document.getElementById('note-modal').innerHTML = '';
+<% else %>
+  // Show validation errors
+  document.getElementById('note-modal').innerHTML = '<%= escape_javascript(render(partial: "edit_note_form", locals: { contact: @contact })) %>';
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,12 @@ Rails.application.routes.draw do
   resources :events, only: [:index, :new]
 
   # Contacts
-  resources :contacts, only: [:index, :new]
+  resources :contacts, only: [:index, :new, :create, :destroy] do
+    member do
+      get :edit_note
+      patch :update_note
+    end
+  end
 
   # Catch all undefined routes
   match "*path", to: "errors#not_found", via: :all

--- a/db/migrate/20251122102031_create_contacts.rb
+++ b/db/migrate/20251122102031_create_contacts.rb
@@ -1,0 +1,13 @@
+class CreateContacts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :contacts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :contact_user, foreign_key: { to_table: :users }
+      t.text :note
+
+      t.timestamps
+    end
+
+    add_index :contacts, [:user_id, :contact_user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_15_003658) do
+ActiveRecord::Schema[7.1].define(version: 2025_11_22_102031) do
+  create_table "contacts", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "contact_user_id"
+    t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contact_user_id"], name: "index_contacts_on_contact_user_id"
+    t.index ["user_id", "contact_user_id"], name: "index_contacts_on_user_id_and_contact_user_id", unique: true
+    t.index ["user_id"], name: "index_contacts_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest", null: false
@@ -32,4 +43,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_15_003658) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "contacts", "users"
+  add_foreign_key "contacts", "users", column: "contact_user_id"
 end

--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -19,3 +19,61 @@ Feature: Contacts Management
     When I navigate to "/contacts"
     Then I should see the search bar
     And I should see "Add Contact" button
+
+  Scenario: User can navigate to add contacts page
+    Given a user exists with email "user@example.com" and password "password123"
+    And I am signed in as "user@example.com" with password "password123"
+    When I navigate to "/contacts"
+    And I click on "Add Contact"
+    Then I should see "Add Contact" heading
+    And I should see "Search for a person to add as a contact"
+
+  Scenario: Add contacts page displays available users
+    Given a user exists with email "user@example.com" and password "password123"
+    And a user exists with email "john@example.com" and password "password123"
+    And a user exists with email "jane@example.com" and password "password123"
+    And I am signed in as "user@example.com" with password "password123"
+    When I navigate to "/contacts/new"
+    Then I should see "john@example.com"
+    And I should see "jane@example.com"
+
+  Scenario: User can add a contact
+    Given a user exists with email "user@example.com" and password "password123"
+    And a user exists with email "john@example.com" and password "password123"
+    And I am signed in as "user@example.com" with password "password123"
+    When I navigate to "/contacts/new"
+    And I click the "Add Contact" button for "john@example.com"
+    Then I should be on the contacts page
+    And I should see "Contact added successfully"
+
+  Scenario: Added contacts appear in contacts list
+    Given a user exists with email "user@example.com" and password "password123"
+    And a user exists with email "john@example.com" and password "password123"
+    And I am signed in as "user@example.com" with password "password123"
+    And I add "john@example.com" as a contact
+    When I navigate to "/contacts"
+    Then I should see the contact with email "john@example.com" in the table
+
+  Scenario: User cannot add duplicate contacts
+    Given a user exists with email "user@example.com" and password "password123"
+    And a user exists with email "john@example.com" and password "password123"
+    And I am signed in as "user@example.com" with password "password123"
+    And I add "john@example.com" as a contact
+    When I navigate to "/contacts/new"
+    Then I should not see "john@example.com" in the available users list
+
+  Scenario: User cannot add themselves as a contact
+    Given a user exists with email "user@example.com" and password "password123"
+    And I am signed in as "user@example.com" with password "password123"
+    When I navigate to "/contacts/new"
+    Then I should not see my own email in the available users list
+
+  Scenario: User can delete a contact
+    Given a user exists with email "user@example.com" and password "password123"
+    And a user exists with email "john@example.com" and password "password123"
+    And I am signed in as "user@example.com" with password "password123"
+    And I add "john@example.com" as a contact
+    When I navigate to "/contacts"
+    And I delete the contact with email "john@example.com"
+    Then I should see "Contact removed successfully"
+    And I should not see "john@example.com" in the contacts table

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe ContactsController, type: :controller do
+  let(:user) { create_user(email: 'controller@example.com') }
+  let(:other_user) { create_user(email: 'other-controller@example.com') }
+
   describe 'GET #index' do
     context 'when user is not logged in' do
       it 'redirects to login page' do
@@ -15,8 +18,6 @@ RSpec.describe ContactsController, type: :controller do
     end
 
     context 'when user is logged in' do
-      let(:user) { create_user(email: 'contact-controller@example.com') }
-
       before do
         session[:user_id] = user.id
       end
@@ -31,9 +32,217 @@ RSpec.describe ContactsController, type: :controller do
         expect(response).to render_template(:index)
       end
 
-      it 'has access to current_user helper' do
+      it 'assigns contacts to @contacts' do
+        user.contacts.create(contact_user: other_user)
         get :index
-        expect(assigns(:current_user)).to eq(user)
+        expect(assigns(:contacts)).to eq([other_user])
+      end
+
+      it 'returns empty contacts array when user has no contacts' do
+        get :index
+        expect(assigns(:contacts)).to be_empty
+      end
+    end
+  end
+
+  describe 'GET #new' do
+    context 'when user is not logged in' do
+      it 'redirects to login page' do
+        get :new
+        expect(response).to redirect_to(login_path)
+      end
+    end
+
+    context 'when user is logged in' do
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'returns a successful response' do
+        get :new
+        expect(response).to be_successful
+      end
+
+      it 'renders the new template' do
+        get :new
+        expect(response).to render_template(:new)
+      end
+
+      it 'assigns available users to @users' do
+        get :new
+        expect(assigns(:users)).to include(other_user)
+      end
+
+      it 'excludes current user from @users' do
+        get :new
+        expect(assigns(:users)).not_to include(user)
+      end
+
+      it 'excludes already added contacts from @users' do
+        user.contacts.create(contact_user: other_user)
+        get :new
+        expect(assigns(:users)).not_to include(other_user)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    context 'when user is not logged in' do
+      it 'redirects to login page' do
+        post :create, params: { contact_user_id: other_user.id }
+        expect(response).to redirect_to(login_path)
+      end
+    end
+
+    context 'when user is logged in' do
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'creates a new contact' do
+        expect {
+          post :create, params: { contact_user_id: other_user.id }
+        }.to change(Contact, :count).by(1)
+      end
+
+      it 'redirects to contacts path on success' do
+        post :create, params: { contact_user_id: other_user.id }
+        expect(response).to redirect_to(contacts_path)
+      end
+
+      it 'sets success notice on creation' do
+        post :create, params: { contact_user_id: other_user.id }
+        expect(flash[:notice]).to eq('Contact added successfully')
+      end
+
+      it 'redirects with alert when contact_user_id is blank' do
+        post :create, params: { contact_user_id: '' }
+        expect(response).to redirect_to(new_contact_path)
+        expect(flash[:alert]).to eq('Please select a contact')
+      end
+
+      it 'redirects with alert when user not found' do
+        post :create, params: { contact_user_id: 9_999_999 }
+        expect(response).to redirect_to(new_contact_path)
+        expect(flash[:alert]).to eq('User not found')
+      end
+
+      it 'prevents duplicate contacts' do
+        user.contacts.create(contact_user: other_user)
+        post :create, params: { contact_user_id: other_user.id }
+        expect(flash[:alert]).to include('Failed to add contact')
+        expect(Contact.where(user_id: user.id, contact_user_id: other_user.id).count).to eq(1)
+      end
+    end
+  end
+
+  describe 'GET #edit_note' do
+    let(:contact) { user.contacts.create(contact_user: other_user, note: 'Test note') }
+
+    context 'when user is not logged in' do
+      it 'redirects to login page' do
+        get :edit_note, params: { id: contact.id }
+        expect(response).to redirect_to(login_path)
+      end
+    end
+
+    context 'when user is logged in' do
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'returns a successful response' do
+        get :edit_note, params: { id: contact.id }
+        expect(response).to be_successful
+      end
+
+      it 'renders without layout' do
+        get :edit_note, params: { id: contact.id }
+        expect(response).to render_template(:edit_note)
+      end
+
+      it 'assigns the contact to @contact' do
+        get :edit_note, params: { id: contact.id }
+        expect(assigns(:contact)).to eq(contact)
+      end
+    end
+  end
+
+  describe 'PATCH #update_note' do
+    let(:contact) { user.contacts.create(contact_user: other_user, note: 'Original note') }
+
+    context 'when user is not logged in' do
+      it 'redirects to login page' do
+        patch :update_note, params: { id: contact.id, contact: { note: 'Updated' } }
+        expect(response).to redirect_to(login_path)
+      end
+    end
+
+    context 'when user is logged in' do
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'updates the contact note' do
+        patch :update_note, params: { id: contact.id, contact: { note: 'Updated note' } }
+        expect(contact.reload.note).to eq('Updated note')
+      end
+
+      it 'redirects to contacts path' do
+        patch :update_note, params: { id: contact.id, contact: { note: 'Updated' } }
+        expect(response).to redirect_to(contacts_path)
+      end
+
+      it 'sets success notice' do
+        patch :update_note, params: { id: contact.id, contact: { note: 'Updated' } }
+        expect(flash[:notice]).to eq('Note updated successfully')
+      end
+
+      it 'handles blank notes' do
+        patch :update_note, params: { id: contact.id, contact: { note: '' } }
+        expect(contact.reload.note).to eq('')
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let(:contact) { user.contacts.create(contact_user: other_user, note: 'Test note') }
+
+    context 'when user is not logged in' do
+      it 'redirects to login page' do
+        delete :destroy, params: { id: contact.id }
+        expect(response).to redirect_to(login_path)
+      end
+    end
+
+    context 'when user is logged in' do
+      before do
+        session[:user_id] = user.id
+      end
+
+      it 'deletes the contact' do
+        contact_id = contact.id
+        delete :destroy, params: { id: contact_id }
+        expect(Contact.find_by(id: contact_id)).to be_nil
+      end
+
+      it 'redirects to contacts path' do
+        delete :destroy, params: { id: contact.id }
+        expect(response).to redirect_to(contacts_path)
+      end
+
+      it 'sets success notice' do
+        delete :destroy, params: { id: contact.id }
+        expect(flash[:notice]).to eq('Contact removed successfully')
+      end
+
+      it 'prevents deleting other users contacts' do
+        another_user = create_user(email: 'another-controller@example.com')
+        their_contact = another_user.contacts.create(contact_user: other_user)
+        
+        expect {
+          delete :destroy, params: { id: their_contact.id }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe Contact, type: :model do
+  let(:user) { create_user(email: 'contact-model@example.com') }
+  let(:other_user) { create_user(email: 'other-contact@example.com') }
+
+  describe 'associations' do
+    it 'belongs to a user' do
+      contact = user.contacts.build(contact_user: other_user)
+      contact.save
+      expect(contact.user).to eq(user)
+    end
+
+    it 'belongs to a contact_user' do
+      contact = user.contacts.build(contact_user: other_user)
+      contact.save
+      expect(contact.contact_user).to eq(other_user)
+    end
+  end
+
+  describe 'validations' do
+    it 'requires user_id' do
+      contact = Contact.new(contact_user: other_user)
+      expect(contact).not_to be_valid
+      expect(contact.errors[:user_id]).to be_present
+    end
+
+    it 'requires contact_user_id' do
+      contact = Contact.new(user: user)
+      expect(contact).not_to be_valid
+      expect(contact.errors[:contact_user_id]).to be_present
+    end
+
+    it 'enforces uniqueness of contact per user' do
+      user.contacts.create(contact_user: other_user)
+      duplicate = user.contacts.build(contact_user: other_user)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:contact_user_id]).to include('can only be added once per user')
+    end
+
+    it 'prevents a user from adding themselves as a contact' do
+      contact = user.contacts.build(contact_user: user)
+      expect(contact).not_to be_valid
+      expect(contact.errors[:contact_user_id]).to include('cannot add yourself as a contact')
+    end
+
+    it 'validates that contact_user_id is a valid user' do
+      contact = Contact.new(user: user, contact_user_id: 99999)
+      expect(contact).not_to be_valid
+      expect(contact.errors[:contact_user_id]).to include('must be a valid user')
+    end
+  end
+
+  describe 'creating a valid contact' do
+    it 'creates successfully with valid attributes' do
+      expect {
+        user.contacts.create(contact_user: other_user, note: 'Test note')
+      }.to change(Contact, :count).by(1)
+    end
+
+    it 'allows note to be nil' do
+      contact = user.contacts.create(contact_user: other_user)
+      expect(contact.note).to be_nil
+    end
+
+    it 'allows note to be empty string' do
+      contact = user.contacts.create(contact_user: other_user, note: '')
+      expect(contact.note).to eq('')
+    end
+
+    it 'allows long notes' do
+      long_note = 'a' * 5000
+      contact = user.contacts.create(contact_user: other_user, note: long_note)
+      expect(contact.reload.note).to eq(long_note)
+    end
+  end
+
+  describe 'updating a contact' do
+    it 'updates the note' do
+      contact = user.contacts.create(contact_user: other_user, note: 'Original')
+      contact.update(note: 'Updated')
+      expect(contact.reload.note).to eq('Updated')
+    end
+
+    it 'clears the note' do
+      contact = user.contacts.create(contact_user: other_user, note: 'Original')
+      contact.update(note: '')
+      expect(contact.reload.note).to eq('')
+    end
+  end
+
+  describe 'destroying a contact' do
+    it 'removes the contact' do
+      contact = user.contacts.create(contact_user: other_user)
+      contact_id = contact.id
+      contact.destroy
+      expect(Contact.find_by(id: contact_id)).to be_nil
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -116,4 +116,39 @@ RSpec.describe User, type: :model do
       expect(user.city).to eq('Springfield')
     end
   end
+
+  describe '.available_for_contact' do
+    let(:user) { create_user(email: 'user@example.com') }
+    let(:contact1) { create_user(email: 'contact1@example.com') }
+    let(:contact2) { create_user(email: 'contact2@example.com') }
+    let(:contact3) { create_user(email: 'contact3@example.com') }
+
+    before do
+      user.contacts.create(contact_user: contact1)
+    end
+
+    it 'returns users available to add as contacts' do
+      available = User.available_for_contact(user)
+      expect(available).to include(contact2, contact3)
+      expect(available).not_to include(user)
+      expect(available).not_to include(contact1)
+    end
+
+    it 'excludes the user themselves' do
+      available = User.available_for_contact(user)
+      expect(available).not_to include(user)
+    end
+
+    it 'excludes already added contacts' do
+      available = User.available_for_contact(user)
+      expect(available).not_to include(contact1)
+    end
+
+    it 'returns empty scope when all other users are already contacts' do
+      user.contacts.create(contact_user: contact2)
+      user.contacts.create(contact_user: contact3)
+      available = User.available_for_contact(user)
+      expect(available.count).to eq(0)
+    end
+  end
 end

--- a/spec/requests/contacts_spec.rb
+++ b/spec/requests/contacts_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Contacts', type: :request do
   let(:user) { create_user(email: 'contactuser@example.com', password: 'password123') }
+  let(:other_user) { create_user(email: 'other@example.com', password: 'password123') }
 
   describe 'unauthenticated user' do
     it 'redirects to login when accessing contacts' do
@@ -12,6 +13,11 @@ RSpec.describe 'Contacts', type: :request do
     it 'sets an alert message when redirected' do
       get contacts_path
       expect(flash[:alert]).to eq('Please log in to continue')
+    end
+
+    it 'redirects to login when accessing new contacts' do
+      get new_contact_path
+      expect(response).to redirect_to(login_path)
     end
   end
 
@@ -46,6 +52,131 @@ RSpec.describe 'Contacts', type: :request do
         expect(response.body).to include(events_path)
         expect(response.body).to include(settings_path)
         expect(response.body).to include('Logout')
+      end
+
+      it 'loads contact map without N+1 queries' do
+        5.times do |i|
+          other = create_user(email: "contact#{i}@example.com", password: 'password123')
+          user.contacts.create(contact_user: other)
+        end
+
+        get contacts_path
+        expect(assigns(:contact_map)).to be_present
+        expect(assigns(:contact_map).size).to eq(5)
+      end
+
+      it 'displays added contacts in a table' do
+        user.contacts.create(contact_user: other_user, note: 'Test note')
+        get contacts_path
+        expect(response.body).to include(other_user.first_name)
+        expect(response.body).to include(other_user.last_name)
+        expect(response.body).to include('Test note')
+      end
+
+      it 'shows "No contacts yet" message when no contacts exist' do
+        get contacts_path
+        expect(response.body).to include('No contacts yet')
+      end
+    end
+
+    describe 'GET /contacts/new' do
+      let(:third_user) { create_user(email: 'third@example.com', password: 'password123') }
+
+      it 'returns success and displays add contact page' do
+        get new_contact_path
+        expect(response).to be_successful
+        expect(response.body).to include('Add Contact')
+      end
+
+      it 'displays search input for users' do
+        get new_contact_path
+        expect(response.body).to include('Search for a person')
+        expect(response.body).to include('users-search-input')
+      end
+
+      it 'displays available users to add' do
+        third_user
+        get new_contact_path
+        expect(response.body).to include('users-table')
+        expect(response.body).to include(third_user.first_name)
+        expect(response.body).to include(third_user.email)
+      end
+
+      it 'excludes current user from the list' do
+        get new_contact_path
+        expect(response.body).not_to include("action=\"/users/#{user.id}\"")
+      end
+
+      it 'excludes already added contacts' do
+        user.contacts.create(contact_user: other_user)
+        get new_contact_path
+        expect(response.body).not_to include(other_user.first_name)
+      end
+    end
+
+    describe 'POST /contacts' do
+      it 'adds a new contact successfully' do
+        expect {
+          post contacts_path, params: { contact_user_id: other_user.id }
+        }.to change(Contact, :count).by(1)
+        expect(response).to redirect_to(contacts_path)
+        expect(flash[:notice]).to eq('Contact added successfully')
+      end
+
+      it 'prevents adding the same contact twice' do
+        user.contacts.create(contact_user: other_user)
+        post contacts_path, params: { contact_user_id: other_user.id }
+        expect(response).to redirect_to(new_contact_path)
+        expect(flash[:alert]).to include('Failed to add contact')
+      end
+
+      it 'redirects with alert when contact_user_id is missing' do
+        post contacts_path, params: { contact_user_id: '' }
+        expect(response).to redirect_to(new_contact_path)
+        expect(flash[:alert]).to eq('Please select a contact')
+      end
+
+      it 'redirects with alert when user not found' do
+        post contacts_path, params: { contact_user_id: 9_999_999 }
+        expect(response).to redirect_to(new_contact_path)
+        expect(flash[:alert]).to eq('User not found')
+      end
+    end
+
+    describe 'PATCH /contacts/:id/update_note' do
+      let(:contact) { user.contacts.create(contact_user: other_user) }
+
+      it 'updates contact note successfully' do
+        patch update_note_contact_path(contact), params: { contact: { note: 'Updated note' } }
+        expect(response).to redirect_to(contacts_path)
+        expect(flash[:notice]).to eq('Note updated successfully')
+        expect(contact.reload.note).to eq('Updated note')
+      end
+
+      it 'returns success response for JS format' do
+        patch update_note_contact_path(contact), params: { contact: { note: 'New note' }, format: :js }
+        expect(response).to be_successful
+      end
+    end
+
+    describe 'DELETE /contacts/:id' do
+      let(:contact) { user.contacts.create(contact_user: other_user, note: 'Test note') }
+
+      it 'deletes a contact successfully' do
+        contact_id = contact.id
+        delete contact_path(contact)
+        expect(Contact.find_by(id: contact_id)).to be_nil
+        expect(response).to redirect_to(contacts_path)
+        expect(flash[:notice]).to eq('Contact removed successfully')
+      end
+
+      it 'prevents deleting other users contacts' do
+        another_user = create_user(email: 'another@example.com', password: 'password123')
+        their_contact = another_user.contacts.create(contact_user: other_user)
+        
+        expect {
+          delete contact_path(their_contact)
+        }.not_to change { Contact.count }
       end
     end
   end


### PR DESCRIPTION
Updated the contacts page to list all contacts for the user. Users can add notes to each of their contacts, and delete contacts from their list. A search bar is above the listing so users can search for specific users in their list. 

A "Add Contacts" button is also on the page, which redirects users to a new page where they can search for other users and add them as a contact to their list.